### PR TITLE
Region names

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,9 @@ Every request to DOODS involves the Detect Request JSON object that looks like t
     // The covers boolean indicates if this region must completely cover the detected object or 
     // not. If covers = true, then the detcted object must be completely inside of this region to match.
     // If covers = false than if any part of this object is inside of this region, it will match.
-    {"top": 0.1, "left": 0.1, "bottom": 0.9, "right": 0.9, "detect": {"*":50}, "covers": false}
+    // If defined, the optional id field will be included in detections that this region matched.  NOTE: 
+    // only the first region (including the global detection) to match an object will be used.
+    {"id": "someregion", "top": 0.1, "left": 0.1, "bottom": 0.9, "right": 0.9, "detect": {"*":50}, "covers": false}
     ...
   ]
 }  

--- a/doods.py
+++ b/doods.py
@@ -185,8 +185,10 @@ class Doods:
                     if d.label in r.detect:
                         if d.confidence >= r.detect[d.label]:
                             ret[i] = d
+                            ret[i].region_id = r.id # Add ID of region for which this passed filters.
                             break
                     elif '*' in r.detect and d.confidence >= r.detect['*']:
                         ret[i] = d
+                        ret[i].region_id = r.id # Add ID of region for which this passed filters.
                         break
         return list(ret.values())

--- a/mqtt.py
+++ b/mqtt.py
@@ -26,7 +26,9 @@ class MQTT():
                 if detect_request.image:
                     detect_response.image = base64.b64encode(detect_response.image).decode('utf-8')
                 for detection in detect_response.detections:
-                    self.mqtt_client.publish(f"doods/detect/{detect_request.id}", payload=json.dumps(detection.asdict()), qos=0, retain=False)
+                    self.mqtt_client.publish(
+                        f"doods/detect/{detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}", 
+                        payload=json.dumps(detection.asdict(include_none=False)), qos=0, retain=False)
 
         except Exception as e:
             self.logger.info(e)

--- a/odrpc.py
+++ b/odrpc.py
@@ -13,6 +13,7 @@ class DetectRegion:
     right: float
     detect: Dict[str, float]
     covers: bool = False
+    id: Optional[str] = None
 
 @dataclass
 class DetectRequest:
@@ -47,6 +48,7 @@ class DetectorsResponse:
 
 @dataclass
 class Detection:
+    region_id: Optional[str] = None
     top: float = 0.0
     left: float = 0.0
     bottom: float = 0.0
@@ -54,8 +56,9 @@ class Detection:
     label: str = ""
     confidence: float = 0.0
 
-    def asdict(self):
-        return asdict(self)
+    def asdict(self, include_none=True):
+        ret = asdict(self)
+        return ret if include_none else clean_none(ret)
 
 @dataclass
 class DetectResponse:


### PR DESCRIPTION
Added support for an optional `id` property on regions that will be returned with detections as `region_id` (and used as sub-topics for MQTT).  This makes it a little easier to say, detect a dog in its pen versus outside or to log which bird feeder of two is preferred.

Because the first region (including the global detection) to match immediately passes the object through the filters, only one region at most will be returned for a detection.  As far as I can tell though, the regions are evaluated in the order in which they are defined, so it's easy enough for the consumer to know that an object in a particular region must *also* be in a larger encompassing region.  Though it's helpful if you're looking for region tags to just replace the global `detect` field with a region covering the whole image.