### PR TITLE
Improved MQTT Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ Every request to DOODS involves the Detect Request JSON object that looks like t
   // a sub-topic based on its type (e.g doods/detect/requestid/regionid/person).  When False, the default,
   // the whole DetectResponse object will be published to the request topic (e.g. doods/detect/requestid).
   "separate_detections" : false,
+  // When in MQTT mode, if crop is true and separate_detections is true requested images will be cropped to 
+  // the decection box.  Has no effect if separate_detections is false.
+  "crop": false,
   // When in MQTT mode, if binary_images is true requested images will be pubished as binary data 
   // to a separate topic (e.g. doods/image/requestid) instead of base64 encoded into the response.
   "binary_images" : false,

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ Every request to DOODS involves the Detect Request JSON object that looks like t
     // grayscale = changes the image to grayscale before processing  
     "grayscale"
   ],
+  // When in MQTT mode, if separate_detections is true each detected object will be published separately into 
+  // a sub-topic based on its type (e.g doods/detect/requestid/regionid/person).  When False, the default,
+  // the whole DetectResponse object will be published to the request topic (e.g. doods/detect/requestid).
+  "separate_detections" : false,
+  // When in MQTT mode, if binary_images is true requested images will be pubished as binary data 
+  // to a separate topic (e.g. doods/image/requestid) instead of base64 encoded into the response.
+  "binary_images" : false,
   // detect is an object of label->confidence matches that will be applied to the entire image
   // The "*" for the label name indicates it can match any label. If a specific label is listed
   // then it cannot be matched by the wildcard. This example matches any label at 50% confidence

--- a/README.md
+++ b/README.md
@@ -66,16 +66,6 @@ Every request to DOODS involves the Detect Request JSON object that looks like t
     // grayscale = changes the image to grayscale before processing  
     "grayscale"
   ],
-  // When in MQTT mode, if separate_detections is true each detected object will be published separately into 
-  // a sub-topic based on its type (e.g doods/detect/requestid/regionid/person).  When False, the default,
-  // the whole DetectResponse object will be published to the request topic (e.g. doods/detect/requestid).
-  "separate_detections" : false,
-  // When in MQTT mode, if crop is true and separate_detections is true requested images will be cropped to 
-  // the decection box.  Has no effect if separate_detections is false.
-  "crop": false,
-  // When in MQTT mode, if binary_images is true requested images will be pubished as binary data 
-  // to a separate topic (e.g. doods/image/requestid) instead of base64 encoded into the response.
-  "binary_images" : false,
   // detect is an object of label->confidence matches that will be applied to the entire image
   // The "*" for the label name indicates it can match any label. If a specific label is listed
   // then it cannot be matched by the wildcard. This example matches any label at 50% confidence
@@ -100,7 +90,20 @@ Every request to DOODS involves the Detect Request JSON object that looks like t
     // only the first region (including the global detection) to match an object will be used.
     {"id": "someregion", "top": 0.1, "left": 0.1, "bottom": 0.9, "right": 0.9, "detect": {"*":50}, "covers": false}
     ...
-  ]
+  ],
+
+  // NOTE: Below fields are only available in requests configured as part of the MQTT configuration
+
+  // If separate_detections is true each detected object will be published separately into 
+  // a sub-topic based on its type (e.g doods/detect/requestid/regionid/person).  When False, the default,
+  // the whole DetectResponse object will be published to the request topic (e.g. doods/detect/requestid).
+  "separate_detections" : false,
+  // If crop is true and separate_detections is true requested images will be cropped to 
+  // the decection box.  Has no effect if separate_detections is false.
+  "crop": false,
+  // If binary_images is true requested images will be pubished as binary data 
+  // to a separate topic (e.g. doods/image/requestid) instead of base64 encoded into the response.
+  "binary_images" : false,
 }  
 ```
 

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 from typing import List, Optional
 from pydantic import BaseSettings, Extra
-from odrpc import DetectRequest
+from odrpc import MqttDetectRequest
 
 class DoodsDetectorConfig(BaseSettings):
     name: str
@@ -69,7 +69,7 @@ class MqttBrokerConfig(BaseSettings):
 
 class MqttConfig(BaseSettings):
     broker: MqttBrokerConfig
-    requests: List[DetectRequest]
+    requests: List[MqttDetectRequest]
     metrics: Optional[bool] = True
     class Config:
         env_prefix = 'mqtt_'

--- a/config.yaml
+++ b/config.yaml
@@ -43,6 +43,7 @@ mqtt:
       detector_name: default
       preprocess: []
       separate_detections: false
+      crop: false
       binary_images: false
       detect:
         "*": 50

--- a/config.yaml
+++ b/config.yaml
@@ -42,6 +42,8 @@ mqtt:
     - id: firstrequest
       detector_name: default
       preprocess: []
+      separate_detections: false
+      binary_images: false
       detect:
         "*": 50
       regions:

--- a/mqtt.py
+++ b/mqtt.py
@@ -37,8 +37,6 @@ class MQTT():
 
 
                     for detection in detect_response.detections:
-                        detection_dict = detection.asdict(include_none=False)
-
                         # If an image was requested
                         if mqtt_detect_request.image:
                             # Crop image to detection box if requested
@@ -58,11 +56,11 @@ class MQTT():
                                     payload=mqtt_image, qos=0, retain=False)
                             # Otherwise add base64-encoded image to the detection
                             else:
-                                detection_dict['image'] = base64.b64encode(mqtt_image).decode('utf-8')
+                                detection.image = base64.b64encode(mqtt_image).decode('utf-8')
 
                         self.mqtt_client.publish(
                             f"doods/detect/{mqtt_detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}/{detection.label or 'object'}", 
-                            payload=json.dumps(detection_dict), qos=0, retain=False)
+                            payload=json.dumps(detection.asdict(include_none=False)), qos=0, retain=False)
                 
                 # Otherwise, publish the collected detections together
                 else:

--- a/mqtt.py
+++ b/mqtt.py
@@ -20,17 +20,17 @@ class MQTT():
         # Borrow the uvicorn logger because it's pretty.
         self.logger = logging.getLogger("doods.mqtt")
 
-    def stream(self, detect_request: str = '{}'):
+    def stream(self, mqtt_detect_request: str = '{}'):
         streamer = None
         try:
             # Run the stream detector and return the results.
-            streamer = Streamer(self.doods).start_stream(detect_request)
+            streamer = Streamer(self.doods).start_stream(mqtt_detect_request)
             for detect_response in streamer:
                 # If separate_detections, iterate over each detection and process it separately
-                if detect_request.separate_detections:
+                if mqtt_detect_request.separate_detections:
 
                     #If we're going to be cropping, do this processing only once (rather than for each detection)
-                    if detect_request.image and detect_request.crop:
+                    if mqtt_detect_request.image and mqtt_detect_request.crop:
                         detect_image_bytes = np.frombuffer(detect_response.image, dtype=np.uint8)
                         detect_image = cv2.imdecode(detect_image_bytes, cv2.IMREAD_COLOR)
                         di_height, di_width = detect_image.shape[:2]
@@ -40,47 +40,47 @@ class MQTT():
                         detection_dict = detection.asdict(include_none=False)
 
                         # If an image was requested
-                        if detect_request.image:
+                        if mqtt_detect_request.image:
                             # Crop image to detection box if requested
-                            if detect_request.crop:
+                            if mqtt_detect_request.crop:
                                 cropped_image = detect_image[
                                 int(detection.top*di_height):int(detection.bottom*di_height), 
                                 int(detection.left*di_width):int(detection.right*di_width)]
-                                mqtt_image = cv2.imencode(detect_request.image, cropped_image)[1].tostring()
+                                mqtt_image = cv2.imencode(mqtt_detect_request.image, cropped_image)[1].tostring()
                             else:
                                 mqtt_image = detect_response.image
 
 
                             # For binary images, publish the image to its own topic
-                            if detect_request.binary_images:
+                            if mqtt_detect_request.binary_images:
                                 self.mqtt_client.publish(
-                                    f"doods/image/{detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}/{detection.label or 'object'}", 
+                                    f"doods/image/{mqtt_detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}/{detection.label or 'object'}", 
                                     payload=mqtt_image, qos=0, retain=False)
                             # Otherwise add base64-encoded image to the detection
                             else:
                                 detection_dict['image'] = base64.b64encode(mqtt_image).decode('utf-8')
 
                         self.mqtt_client.publish(
-                            f"doods/detect/{detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}/{detection.label or 'object'}", 
+                            f"doods/detect/{mqtt_detect_request.id}{'' if detection.region_id is None else '/'+detection.region_id}/{detection.label or 'object'}", 
                             payload=json.dumps(detection_dict), qos=0, retain=False)
                 
                 # Otherwise, publish the collected detections together
                 else:
                     # If an image was requested
-                    if detect_request.image:
+                    if mqtt_detect_request.image:
                         # If binary_images, move the image from the response and publish it to a separate topic
-                        if detect_request.binary_images:
+                        if mqtt_detect_request.binary_images:
                             mqtt_image = detect_response.image
                             detect_response.image = None
                             self.mqtt_client.publish(
-                                f"doods/image/{detect_request.id}", 
+                                f"doods/image/{mqtt_detect_request.id}", 
                                 payload=detect_response.image, qos=0, retain=False)
                         # Otherwise, inlcude the base64-encoded image in the response
                         else:
                             detect_response.image = base64.b64encode(detect_response.image).decode('utf-8')
                     
                     self.mqtt_client.publish(
-                            f"doods/detect/{detect_request.id}", 
+                            f"doods/detect/{mqtt_detect_request.id}", 
                             payload=json.dumps(detect_response.asdict(include_none=False)), qos=0, retain=False)
                     
 

--- a/odrpc.py
+++ b/odrpc.py
@@ -22,6 +22,7 @@ class DetectRequest:
     image: Optional[str] = ""
     throttle: Optional[float] = 0.0
     separate_detections: Optional[bool] = False
+    crop: Optional[bool] = False
     binary_images: Optional[bool] = False
     data: str = ""
     preprocess: List[str] = field(default_factory=list)

--- a/odrpc.py
+++ b/odrpc.py
@@ -21,6 +21,8 @@ class DetectRequest:
     detector_name: Optional[str] = None
     image: Optional[str] = ""
     throttle: Optional[float] = 0.0
+    separate_detections: Optional[bool] = False
+    binary_images: Optional[bool] = False
     data: str = ""
     preprocess: List[str] = field(default_factory=list)
     detect: Dict[str, float] = field(default_factory=dict)

--- a/odrpc.py
+++ b/odrpc.py
@@ -21,13 +21,16 @@ class DetectRequest:
     detector_name: Optional[str] = None
     image: Optional[str] = ""
     throttle: Optional[float] = 0.0
-    separate_detections: Optional[bool] = False
-    crop: Optional[bool] = False
-    binary_images: Optional[bool] = False
     data: str = ""
     preprocess: List[str] = field(default_factory=list)
     detect: Dict[str, float] = field(default_factory=dict)
     regions: List[DetectRegion] = field(default_factory=list)    
+
+@dataclass
+class MqttDetectRequest(DetectRequest):
+    separate_detections: Optional[bool] = False
+    crop: Optional[bool] = False
+    binary_images: Optional[bool] = False
 
 @dataclass
 class Detector:

--- a/odrpc.py
+++ b/odrpc.py
@@ -61,6 +61,7 @@ class Detection:
     right: float = 0.0
     label: str = ""
     confidence: float = 0.0
+    image: Optional[str] = None
 
     def asdict(self, include_none=True):
         ret = asdict(self)


### PR DESCRIPTION
New config settings:
- Added `separate_detections` to control whether detections are split out into separate MQTT sub-topics (e.g. for convenient consumption by Home Assistant without needing to parse JSON objects) or kept as a single JSON object (e.g. for counting the number of objects detected in a single frame).
- Added `crop` to crop output images to just the detection box when `separate_detections` is turned on.  This is potentially useful if the output will be fed into a downstream service for additional processing (like face detection, license plate reading, etc.)
- Added `binary_images` to specify if images should be published to a separate `../image/..` topic for convenient consumption in binary form by e.g. Home Assistant's MQTT camera integration, or base64 encoded and included with the detection JSON.

All of these have been added to the DetectRequest configuration to allow for flexibility (so you could have a binary MQTT image stream for getting picked up by Home Assistant, but still publish separated base64 images to collect photos of each bird that visited your house... or something).  However, these settings will have no effect when doods2 is running in API mode (for the time being anyway-- I'm not sure if they would really work as well with most of the API options).

NOTE: These changes will affect the default behavior of MQTT mode; specifically `separate_detections` was sort of implicitly on previously, and will now default to off to better match the API default.  Hopefully not enough people have started using MQTT mode for this to be a big hassle.