### PR TITLE
Add duration to DetectResponse

### DIFF
--- a/doods.py
+++ b/doods.py
@@ -3,6 +3,7 @@ import logging
 import numpy as np
 import cv2
 import odrpc
+import time
 
 from detectors.tensorflow import Tensorflow
 from detectors.tflite import TensorflowLite
@@ -134,9 +135,12 @@ class Doods:
         image = cv2.cvtColor(image, cv2.COLOR_BGR2RGB)
 
         # Run detection
+        start = time.perf_counter()
         ret = detector.detect(image)
         if ret.error:
             return ret
+        # Detection duration in milliseconds.
+        ret.duration = (time.perf_counter() - start) * 1000
 
         # Set the id        
         ret.id = detect.id

--- a/odrpc.py
+++ b/odrpc.py
@@ -73,6 +73,7 @@ class DetectResponse:
     image: Optional[str] = None
     detections: List[Detection] = field(default_factory=list)
     error: Optional[str] = None
+    duration: Optional[int] = None
 
     def asdict(self, include_none=True):
         ret = asdict(self)


### PR DESCRIPTION
I noticed doods2 is missing detection duration metrics in logs that was present in the original doods repo. I found it helpful, so I'm requesting to add it back :).