### PR TITLE
Improve reliability of streaming

### DIFF
--- a/mqtt.py
+++ b/mqtt.py
@@ -81,9 +81,7 @@ class MQTT():
                             f"doods/detect/{mqtt_detect_request.id}", 
                             payload=json.dumps(detect_response.asdict(include_none=False)), qos=0, retain=False)
                     
-
-        except Exception as e:
-            self.logger.info(e)
+        finally:
             try:
                 if streamer:
                     streamer.send(True)  # Stop the streamer

--- a/streamer.py
+++ b/streamer.py
@@ -3,32 +3,44 @@ import cv2
 import asyncio
 import odrpc
 import time
+import logging
 from fresh_frame import FreshestFrame
 
 class Streamer:
     def __init__(self, doods):
         self.doods = doods
+        self.logger = logging.getLogger("doods.streamer")
 
     def start_stream(self, detect_request: odrpc.DetectRequest):
-        vcap = cv2.VideoCapture(detect_request.data, cv2.CAP_FFMPEG)
-        vcap = FreshestFrame(vcap)
+        url = detect_request.data
+
         last_frame_time = 0
+        vcap = self.create_vcap(url)
         while True:
             # Handle throttling
             if time.time() - last_frame_time < detect_request.throttle:
                 time.sleep(detect_request.throttle - (time.time() - last_frame_time))
             last_frame_time = time.time()
-    
+
             # Get a frame
-            ret, detect_request.data = vcap.read()
-            if ret == False:
+            seqnum, detect_request.data = vcap.read()
+            if detect_request.data is None:
+                self.logger.error("Got no data back from video capture. Assuming stream error and attempting to re-create...")
+                vcap.release()
+                vcap = self.create_vcap(url)
                 continue
+
             detect_response = self.doods.detect(detect_request)
-            
+
             stop = yield detect_response
             if stop:
                 vcap.release()
                 return
+
+    def create_vcap(self, url):
+        vcap = cv2.VideoCapture(url, cv2.CAP_FFMPEG)
+        vcap = FreshestFrame(vcap)
+        return vcap
 
     @staticmethod
     async def mjpeg_streamer(gen):


### PR DESCRIPTION
In order to allow doods2 to recover from errors in the stream when using the websocket based stream API or MQTT mode, detect when the `VideoCapture` is not returning data and then re-create it in order to try to fix the stream. Since we are waiting infinitely for the `VideoCapture` to return data, the fact that it returned no data means it has likely encountered some sort of unrecoverable error that can only be fixed by re-creating it.

This should fix https://github.com/snowzach/doods2/issues/74

### Testing
* Rebooting camera before patch where doods get stuck in an infinite loop and uses ~100% CPU
  ```
  # docker logs doods -n 3
  2022-12-31 22:36:44,892 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=32.101302000228316)
  2022-12-31 22:36:45,299 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=31.982888001948595)
  2022-12-31 22:37:15,353 - doods.mqtt - INFO - 'NoneType' object has no attribute 'startswith'
  # top -bcn1 | grep mqtt
  3694349 root      20   0   18.0g   4.4g 994.8m S  93.8  14.1   0:33.81 python3 main.py mqtt
  ```

* Rebooting camera after patch where doods recovers and uses normal CPU:
  ```
  # docker logs doods -n 5
  2022-12-31 22:44:28,830 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=29.453716007992625)
  2022-12-31 22:44:29,335 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=32.27406900259666)
  2022-12-31 22:45:29,559 - doods.streamer - ERROR - Got no data back from video capture. Assuming stream error and attempting to re-create...
  2022-12-31 22:45:31,767 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=43.023940990678966)
  2022-12-31 22:45:32,272 - doods.doods - INFO - DetectResponse(id='default', image=None, detections=[], error=None, duration=31.51911002350971)
  # top -bcn1 | grep mqtt
  3680077 root      20   0   18.0g   4.5g 995.4m S  26.7  14.3   1:34.06 python3 main.py mqtt
  ```

