### PR TITLE
Fix deps : pytorch/pytorch: No module named 'ultralytics'

### DIFF
--- a/requirements.pytorch.txt
+++ b/requirements.pytorch.txt
@@ -6,3 +6,4 @@ image>=1.5.0
 tqdm>=4.64.0
 ipython>=8.5.0
 psutil>=5.9.3
+ultralytics>=8.0.105


### PR DESCRIPTION
Fix the error:

doods.doods - ERROR - Could not create detector pytorch/pytorch: No module named 'ultralytics'