### PR TITLE
Use newer tensorflow image to be compatible with torch version

### DIFF
--- a/docker/Dockerfile.base.amd64
+++ b/docker/Dockerfile.base.amd64
@@ -1,4 +1,4 @@
-FROM docker.io/tensorflow/tensorflow:2.7.0 as base
+FROM docker.io/tensorflow/tensorflow:2.13.0 as base
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.base.amd64-gpu
+++ b/docker/Dockerfile.base.amd64-gpu
@@ -1,7 +1,4 @@
-FROM docker.io/tensorflow/tensorflow:2.7.0-gpu as base
-
-# Remove nvidia repos as they are no longer signed with the included key and we don't need to update them anyhow.
-RUN rm /etc/apt/sources.list.d/nvidia-ml.list /etc/apt/sources.list.d/cuda.list
+FROM docker.io/tensorflow/tensorflow:2.13.0-gpu as base
 
 # Install dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.base.tf2od.amd64
+++ b/docker/Dockerfile.base.tf2od.amd64
@@ -1,4 +1,4 @@
-FROM docker.io/tensorflow/tensorflow:2.7.0 as base
+FROM docker.io/tensorflow/tensorflow:2.13.0 as base
 
 # Install apt dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docker/Dockerfile.base.tf2od.amd64-gpu
+++ b/docker/Dockerfile.base.tf2od.amd64-gpu
@@ -1,4 +1,4 @@
-FROM docker.io/tensorflow/tensorflow:2.7.0-gpu as base
+FROM docker.io/tensorflow/tensorflow:2.13.0-gpu as base
 
 # Install apt dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \


### PR DESCRIPTION
This should fix #92, which appears to be caused by a mismatch between versions of CUDA (in the tensorflow -gpu image) and torch.

The Dockerfile is using a specific version of tensorflow (2.7.0 in this case) that contains an older version of CUDA, whereas torch is being installed without specifying a version – so it's installing the latest, which relies on a newer version of CUDA.

As a workaround for the currently-published `snowzach/doods2:amd64-gpu` image, you can downgrade torch in the image with something like:
```
pip install torch==1.12.1+cu113 torchvision==0.13.1+cu113 --extra-index-url https://download.pytorch.org/whl/cu113
```

It might be a good idea to specify the torch version (in the Dockerfile) in the future, but I guess that's up to the project maintainer.
