### PR TITLE
Support for YOLOv8 based models

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,11 +42,11 @@ jobs:
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
-      - name: Install cosign
-        if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
-        with:
-          cosign-release: 'v1.4.0'
+      # - name: Install cosign
+      #   if: github.event_name != 'pull_request'
+      #   uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
+      #   with:
+      #     cosign-release: 'v1.4.0'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,11 +42,11 @@ jobs:
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
-      # - name: Install cosign
-      #   if: github.event_name != 'pull_request'
-      #   uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
-      #   with:
-      #     cosign-release: 'v1.4.0'
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@1e95c1de343b5b0c23352d6417ee3e48d5bcd422
+        with:
+          cosign-release: 'v1.4.0'
 
 
       # Workaround: https://github.com/docker/build-push-action/issues/461

--- a/README.md
+++ b/README.md
@@ -297,12 +297,13 @@ services:
 ```
 
 # Supported Detectors / Models
-There are currently 3 supported dectector formats
+There are currently 5 supported dectector formats
 - tflite - Tensorflow lite `.tflite` models
 - tensorflow - Original tensoflow frozen models (Usually end with `.pb`)
-- pytorch - PyTorch based models like yolo
+- pytorch - PyTorch based models like yolov5
 - deepstack - Deepstack models suppor
-- tensorflow2 - DISABLED - The libraries required were huge (2.2GB) and it was too slow to be ussful for the time being.
+- yolov8 - YOLOv8 based models
+- tensorflow2 - DISABLED - The libraries required were huge (2.2GB) and it was too slow to be useful for the time being.
 
 ## Other Options
 - labelsStartFromZero: true - The labels file starts from index zero instead of 1 like most labels.
@@ -352,6 +353,9 @@ All you need to do is download the .pt files and list them as the model file in 
 If you receive a message that says `No module named 'models.yolo'` you are using a model that expects a very specific directory
 layout. You can fix the issue by downloading this file into your models directory adjacent to your model:
 `https://raw.githubusercontent.com/johnolafenwa/deepstack-trainer/main/models/yolo.py` This should resolve your issue.
+
+## YOLOv8 - .pt files
+Support for Ultralytics YOLOv8 based models. Provide a .pt file as model file in the config. Labels are embedded.
 
 ## Tensorflow 2 - Model Directory
 REMOVED: The dependencies for Tensorflow 2 Object detection were massive and it was really slow so I removed it for the time being.

--- a/detectors/yolov8.py
+++ b/detectors/yolov8.py
@@ -1,0 +1,33 @@
+from ultralytics import YOLO
+from config import DoodsDetectorConfig
+
+class YOLOv8:
+    def __init__(self, config: DoodsDetectorConfig):
+        self.config = odrpc.Detector(**{
+            'name': config.name,
+            'type': 'yolov8',
+            'labels': [],
+            'model': config.modelFile,
+        })
+        self.logger = logging.getLogger("doods.yolov8."+config.name)
+        self.device = torch.device("cuda:0" if config.hwAccel else "cpu")
+        repo, modelName = config.modelFile.split(',',1)
+        self.torch_model = torch.hub.load(repo.strip(), modelName.strip())
+        self.model = YOLO(config.modelFile.strip())
+        self.labels = self.model.names
+        self.config.labels = self.labels
+
+    def detect(self, image):
+
+        results = model.predict(source = image, verbose = True)
+        (height, width, colors) = image.shape
+
+        ret = odrpc.DetectResponse()
+
+        for box in results[0].boxes:
+            (detection.top, detection.left, detection.bottom, detection.right) = box.xyxy.numpy()
+            detection.confidence = box.conf.numpy()
+            detection.label = self.labels[result['cls'].numpy()]
+            ret.detections.append(detection)
+    
+        return ret

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,5 +1,5 @@
 ARG TAG=amd64
-FROM docker.io/snowzach/doods2:base-$TAG as base
+FROM docker.io/snowzach/doods2:base-$TAG AS base
 
 COPY --from=docker.io/snowzach/doods2:base-config /opt/doods/models /opt/doods/models
 COPY --from=docker.io/snowzach/doods2:base-config /opt/doods/config.yaml /opt/doods/config.yaml
@@ -12,7 +12,7 @@ WORKDIR /opt/doods
 
 ADD . .
 
-ENV TF_CPP_MIN_LOG_LEVEL 3
+ENV TF_CPP_MIN_LOG_LEVEL=3
 
 ENTRYPOINT ["python3", "main.py"]
 CMD ["api"]

--- a/doods.py
+++ b/doods.py
@@ -34,6 +34,13 @@ try:
 except ModuleNotFoundError:
     logger.info("Tensorflow2 Object Detection API not installed...")
 
+try:
+    from detectors.yolov8 import YOLOv8
+    detectors['yolov8'] = YOLOv8
+except ModuleNotFoundError:
+    logger.info('YOLOv8 not installed...')
+
+
 font                   = cv2.FONT_HERSHEY_PLAIN
 fontScale              = 1.2
 thickness              = 1


### PR DESCRIPTION
Using the ultralytics library directly.

Use case for me is a custom model that I trained based on the YOLOv8 model and only afterwards realized that thats not supported (yet) in doods2.

In my hands, this is working locally using the web UI. End goal would be to expose it to home assistant through your fantastic hassio add-on, which obviously is much easier if this gets to "mainline"...