### PR TITLE
Add tflite support to yolo (and build images for branches)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -7,7 +7,8 @@ name: Docker
 
 on:
   push:
-    branches: [ master , mqtt-support]
+    branches: 
+      - '*' # Run on any branch with no '/' in it.
     # Publish semver tags as releases.
     tags: [ 'v*.*.*' ]
   pull_request:

--- a/detectors/yolo.py
+++ b/detectors/yolo.py
@@ -2,6 +2,7 @@ import odrpc
 import logging
 from ultralytics import YOLO as uYOLO
 from config import DoodsDetectorConfig
+from tensorflow.lite.python.interpreter import Interpreter
 
 class YOLO:
     def __init__(self, config: DoodsDetectorConfig):
@@ -12,17 +13,27 @@ class YOLO:
             'labels': [],
             'model': config.modelFile,
         })
+        self.hwAccel = config.hwAccel
+        self.predict_args = {}
+
         self.logger = logging.getLogger("doods.yolo."+config.name)
-        self.model = uYOLO(config.modelFile.strip())
+        self.model = uYOLO(config.modelFile.strip(),task='detect')
         if isinstance(self.model.names, dict):
             self.labels = list(self.model.names.values())
         else:
             self.labels = self.model.names
         self.config.labels = self.labels
 
-    def detect(self, image):
+        # If using a tflite model, retrieve the imgsz from an interpreter
+        if self.config.model.endswith('.tflite'):
+            interpreter = self.buildTfliteInterpreter()
+            interpreter.allocate_tensors()
+            input_details = interpreter.get_input_details()
+            img_height, img_width = input_details[0]['shape'][1:3]
+            self.predict_args['imgsz'] = [img_height, img_width]
 
-        results = self.model.predict(source = image, verbose = True)
+    def detect(self, image):
+        results = self.model.predict(source = image, verbose = True, **self.predict_args)
         (height, width, colors) = image.shape
 
         ret = odrpc.DetectResponse()
@@ -39,3 +50,26 @@ class YOLO:
             ret.detections.append(detection)
     
         return ret
+    
+    # Builds a tflite interpreter (a duplicate of the function in tflite.py)
+    def buildTfliteInterpreter(self):
+        # Load the Tensorflow Lite model.
+        # If using Edge TPU, use special load_delegate argument
+        if self.hwAccel:
+            from tensorflow.lite.python.interpreter import load_delegate
+            try:
+                interpreter = Interpreter(model_path=self.config.model,
+                    experimental_delegates=[load_delegate('libedgetpu.so.1.0')])
+            # This might fail the first time as this seems to load the drivers for the EdgeTPU the first time.
+            # Doing it again will load the driver. 
+            except ValueError:
+                try:
+                    interpreter = Interpreter(model_path=self.config.model,
+                        experimental_delegates=[load_delegate('libedgetpu.so.1.0')])
+                except ValueError:
+                    raise ValueError('Could not load EdgeTPU detector')
+        else:
+            interpreter = Interpreter(model_path=self.config.model)
+        
+        interpreter.allocate_tensors()
+        return interpreter


### PR DESCRIPTION
Added support for tflite models to the new `yolo` detector.  This is different from the existing `tflite` detector in that it has support for YOLOv8 (and possibly others-- I can't use my ultralytics-exported YOLOv8 with the regular `tflite` detector, but it's possible I could tweak some of the export settings to get it to work.  Regardless this seems to streamline the process in that any tflite models exported from ultralytics should be compatible with `yolo`).

I have some areas that I think could use some feedback though.  `.tflite` models don't contain imgsz information the way the default `.pt` do, so I have to get this size info from an interpreter.

- I'm switching based on `.endswith('.tflite')`, do you know off-hand a better way to do this?  I think it should be fairly reliable, but another option would be to add e.g. a 'subtype' configuration to the detector, but that seems like extra work rather than going by file extension.
- I borrowed the whole `buildTfliteInterpreter()` function from `tflite.py`.  Could there be a way to share this instead?
- Rather than mess with the interpreter at all, we could just *require* that users provide an explicit imgsz configuration value for tflite models.  It makes it less convenient for users, but reduces code complexity.
- I feel like I'm referencing / using `hwAccel` awkwardly here, but I think it's needed to build the interpreter correctly.

Other than those rough edges, this does test successfully for me using yolov8s on tflite, and volov10 without using the TPU (but also it's pretty darn fast even then, v10 might be pretty good).